### PR TITLE
Fixed the like redirect bug

### DIFF
--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -85,7 +85,7 @@
                     {
                     <form asp-page-handler="Unlike" method="post" class = "spaceright">
                         <input hidden="hidden" type="text" asp-for="LikedCheepId" value="@cheep.Id"/>
-                        <button class="unlikebutton" type="submit">Like</button>
+                        <button class="unlikebutton" type="submit">Disike</button>
                     </form>
                     }
 

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -132,7 +132,7 @@ public class UserTimelineModel : PageModel
             await _service.AddLike(authorName, LikedCheepId.Value);
         }
         
-        return RedirectToPage("Public");
+        return RedirectToPage("UserTimeline");
     }
     
     public async Task<IActionResult> OnPostUnlike()
@@ -144,7 +144,7 @@ public class UserTimelineModel : PageModel
             await _service.RemoveLike(authorName, LikedCheepId.Value);
         }
         
-        return RedirectToPage("Public");
+        return RedirectToPage("UserTimeline");
     }
     
 }


### PR DESCRIPTION
When liking a cheep on private timeline, it no longer redirects to public timeline