### PR TITLE
Fixed pagination

### DIFF
--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -94,7 +94,17 @@
     }
 
     <div class="pagination">
-        <a href="?page=@(Model.PageNumber > 1 ? Model.PageNumber - 1 : 1)"><</a>
+        @{
+            if (Model.PageNumber > 1)
+            {
+                <a href="?page=@(Model.PageNumber > 1 ? Model.PageNumber - 1 : 1)">&lt</a>
+            }
+        }
         <h3>@Model.PageNumber</h3>
-        <a href="?page=@(Model.PageNumber + 1)">></a>
+        @{
+            if (Model.Cheeps.Count >= 32)
+            {
+                <a href="?page=@(Model.PageNumber + 1)">></a>
+            }
+        }
     </div>

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -40,7 +40,7 @@ public class PublicModel : PageModel
         }
         
         
-        if ( page == 0 )
+        if ( page == 0  || page < 0)
         {
             PageNumber = 1;
         }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -101,10 +101,20 @@
     {
         <em>There are no cheeps so far.</em>
     }
-    
+
     <div class="pagination">
-        <a href="?page=@(Model.PageNumber > 1 ? Model.PageNumber - 1 : 1)"><</a>
+        @{
+        if (Model.PageNumber > 1)
+        {
+        <a href="?page=@(Model.PageNumber > 1 ? Model.PageNumber - 1 : 1)">&lt</a>
+        }
+        }
         <h3>@Model.PageNumber</h3>
+        @{
+        if (Model.Cheeps.Count >= 32)
+        {
         <a href="?page=@(Model.PageNumber + 1)">></a>
+        }
+        }
     </div>
 </div>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -47,7 +47,7 @@ public class UserTimelineModel : PageModel
             Cheeps = await _service.GetCheepsFromAuthor(page, author, User.Identity.Name);
         }
         
-        if ( page == 0 )
+        if ( page == 0  || page < 0)
         {
             PageNumber = 1;
         }


### PR DESCRIPTION
Pagination now better reflects what the user can expect.

When on page 1, you can no longer click previous page, as it just redirects to the same page.

When the page contains less than 32 cheeps, you can no longer go to next page, as they will be empty.