### PR TITLE
Length constraint on cheep

### DIFF
--- a/src/Chirp.Web/Pages/Shared/Components/Timeline/Timeline.cshtml
+++ b/src/Chirp.Web/Pages/Shared/Components/Timeline/Timeline.cshtml
@@ -10,7 +10,7 @@
         <div class="cheepbox">
             <h3>Send cheep:</h3>
             <form asp-page-handler="SendCheep" method="post">
-                <input type="text" asp-for="CheepMessage" required>
+                <input type="text" asp-for="CheepMessage" required maxlength="160">
                 <div class="container">
                     <input type="submit" value="Share">
                     <p>Max 160 characters</p>


### PR DESCRIPTION
We lost a line of code to ensure you cant write more than 160 characters when refactoring  the razor pages.